### PR TITLE
feat: adds CreateFFmpegParam.mainName parameter to enable single-thread ffmpeg-core 

### DIFF
--- a/lib/src/ffmpeg.dart
+++ b/lib/src/ffmpeg.dart
@@ -10,13 +10,20 @@ import 'package:js/js_util.dart';
 @JS()
 @anonymous
 abstract class CreateFFmpegParam {
-  external factory CreateFFmpegParam({bool? log, String? corePath});
+  external factory CreateFFmpegParam({
+    bool? log,
+    String? corePath,
+    String? mainName,
+  });
 
   /// Whether Enable or Disable ffmpeg log to console.
   external bool? get log;
 
   /// Path URL of ffmpeg-core library.
   external String? get corePath;
+
+  /// Main name of ffmpeg-core library function.
+  external String? get mainName;
 }
 
 @JS()

--- a/lib/src/none/ffmpeg.dart
+++ b/lib/src/none/ffmpeg.dart
@@ -4,10 +4,15 @@ library ffmpeg;
 import 'dart:typed_data';
 
 abstract class CreateFFmpegParam {
-  external factory CreateFFmpegParam({bool? log, String? corePath});
+  external factory CreateFFmpegParam({
+    bool? log,
+    String? corePath,
+    String? mainName,
+  });
 
   bool? get log;
   String? get corePath;
+  String? get mainName;
 }
 
 class FFmpeg {}


### PR DESCRIPTION
# Description 

A well-known problem regarding `ffmpeg.wasm` is that by default it uses a multi-thread implementation of `ffmpeg-core`, which implements `SharedArrayBuffer`. That forces us to enable some security policies that are very tricky to configure and maintain in complex enterprise applications, such as we have at @quintoandar. 

An alternative to make this implementation easier and completely discard `SharedArrayBuffer`, is to use a single-thread version of `ffmpeg-core`, as thankfully mentioned at https://github.com/ffmpegwasm/ffmpeg.wasm/issues/137#issuecomment-1014956114 

I could achieve satisfactory results through this approach, and all I had to do was slightly adapting this package's code to include `CreateFFmpegParam.mainName` parameter. For example: 

```dart
final ffmpeg = createFFmpeg(
  CreateFFmpegParam(
    corePath: 'https://unpkg.com/@ffmpeg/core-st@0.11.1/dist/ffmpeg-core.js',
    mainName: 'main',
  ),
);
```

I believe it'd be great to have this option available at `ffmpeg_wasm`, so developers could choose not to rely on `SharedArrayBuffer` - if they are willing to sacrifice performance for that, like I am.